### PR TITLE
set repo attribute to true instead of false

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -163,7 +163,7 @@ default['mariadb']['install']['extra_packages'] = true
 #
 # package(apt or yum) default configuration
 #
-default['mariadb']['use_default_repository'] = false
+default['mariadb']['use_default_repository'] = true
 default['mariadb']['apt_repository']['base_url'] = \
   'ftp.igh.cnrs.fr/pub/mariadb/repo'
 


### PR DESCRIPTION
The cookbook, by default, sets `default['mariadb']['use_default_repository']` to false because they assume we have an in house repository. Switching this value to `true` allows the cookbook to complete with the `mysql` service running on the following distributions. 

CentOS 6, CentOS 7, RHEL 6, RHEL 7.  

I have avoided pulling in the most recent version of this cookbook (`sinfomicien/mariadb`) as it has additional chef dependancies.